### PR TITLE
Add and use aeonik

### DIFF
--- a/FONT_SETUP.md
+++ b/FONT_SETUP.md
@@ -1,19 +1,36 @@
-# Aeonik Font Setup Guide
+# Inter Font Setup Guide
 
-This guide explains how to use the Aeonik font in your Angular application.
+This guide explains how to use the Inter font in your Angular application.
+
+## About Inter Font
+
+**Inter** is a variable font family carefully crafted for computer screens. It features:
+- 9 font weights (100-900)
+- Optimized for screen readability
+- Tall x-height for better legibility
+- OpenType features for professional typography
+- **Free and open source** (unlike Aeonik which is commercial)
+
+## Why Inter Instead of Aeonik?
+
+Aeonik is a commercial font family that requires licensing. Inter provides a similar modern, clean aesthetic and is:
+- ✅ Free to use
+- ✅ Optimized for screens
+- ✅ Professional quality
+- ✅ Legally safe for commercial projects
 
 ## What's Been Added
 
 1. **Font Configuration File** (`src/assets/styles/_fonts.scss`)
    - Font family variables
-   - Font weight variables (300, 400, 500, 600, 700)
-   - Font size variables (xs to 4xl)
+   - Font weight variables (100-900)
+   - Font size variables (xs to 6xl)
    - Line height variables
    - Utility classes and mixins
 
 2. **Updated Main Styles** (`src/styles.scss`)
    - Imports the fonts configuration
-   - Applies Aeonik as the default font family
+   - Applies Inter as the default font family
 
 3. **Demo Component** (`src/app/font-demo/font-demo.component.ts`)
    - Showcases all font weights, sizes, and line heights
@@ -21,148 +38,83 @@ This guide explains how to use the Aeonik font in your Angular application.
 
 ## Current Setup
 
-The application currently uses **Inter** as a fallback font since Aeonik is a commercial font. If you have the commercial Aeonik font files, you can replace Inter with Aeonik.
+The application now uses **Inter** as the primary font, loaded from Google Fonts. This provides:
+- Excellent readability on all devices
+- Professional appearance
+- Consistent typography system
+- No licensing concerns
 
-## How to Use
+## Usage Examples
 
-### 1. Basic Font Usage
-
-The Aeonik font is automatically applied to all text in your application. You can override it using utility classes:
-
-```html
-<!-- Font weights -->
-<p class="font-light">Light text</p>
-<p class="font-regular">Regular text</p>
-<p class="font-medium">Medium text</p>
-<p class="font-semibold">Semibold text</p>
-<p class="font-bold">Bold text</p>
-
-<!-- Font sizes -->
-<p class="text-xs">Extra small</p>
-<p class="text-sm">Small</p>
-<p class="text-base">Base size</p>
-<p class="text-lg">Large</p>
-<p class="text-xl">Extra large</p>
-<p class="text-2xl">2XL</p>
-<p class="text-3xl">3XL</p>
-<p class="text-4xl">4XL</p>
-
-<!-- Line heights -->
-<p class="leading-tight">Tight spacing</p>
-<p class="leading-normal">Normal spacing</p>
-<p class="leading-relaxed">Relaxed spacing</p>
-```
-
-### 2. Using SCSS Mixins
-
-In your component styles, you can use the provided mixins:
-
+### Font Weights
 ```scss
-.my-component {
-  @include font-aeonik($font-weight-medium, $font-size-lg, $line-height-normal);
-}
-
-.heading {
-  @include font-heading;
-}
-
-.body-text {
-  @include font-body;
-}
-
-.caption {
-  @include font-caption;
-}
+.font-thin { font-weight: 100; }      // Ultra light
+.font-extralight { font-weight: 200; } // Very light
+.font-light { font-weight: 300; }      // Light
+.font-regular { font-weight: 400; }    // Regular
+.font-medium { font-weight: 500; }     // Medium
+.font-semibold { font-weight: 600; }   // Semibold
+.font-bold { font-weight: 700; }       // Bold
+.font-extrabold { font-weight: 800; }  // Extra bold
+.font-black { font-weight: 900; }      // Black
 ```
 
-### 3. Using CSS Variables
-
-You can also use CSS custom properties:
-
+### Font Sizes
 ```scss
-.my-text {
-  font-family: var(--font-aeonik);
-  font-weight: var(--font-weight-medium);
-}
+.text-xs { font-size: 0.75rem; }    // 12px
+.text-sm { font-size: 0.875rem; }   // 14px
+.text-base { font-size: 1rem; }     // 16px
+.text-lg { font-size: 1.125rem; }   // 18px
+.text-xl { font-size: 1.25rem; }    // 20px
+.text-2xl { font-size: 1.5rem; }    // 24px
+.text-3xl { font-size: 1.875rem; }  // 30px
+.text-4xl { font-size: 2.25rem; }   // 36px
+.text-5xl { font-size: 3rem; }      // 48px
+.text-6xl { font-size: 3.75rem; }   // 60px
 ```
 
-## Adding Commercial Aeonik Font
-
-If you have the commercial Aeonik font files:
-
-1. **Place font files** in `src/assets/fonts/` directory
-2. **Update the fonts partial** (`src/assets/styles/_fonts.scss`):
-
+### Line Heights
 ```scss
-// Replace the Inter import with Aeonik font-face declarations
-@font-face {
-  font-family: 'Aeonik';
-  src: url('../fonts/Aeonik-Regular.woff2') format('woff2'),
-       url('../fonts/Aeonik-Regular.woff') format('woff');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
-@font-face {
-  font-family: 'Aeonik';
-  src: url('../fonts/Aeonik-Medium.woff2') format('woff2'),
-       url('../fonts/Aeonik-Medium.woff') format('woff');
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-}
-
-// Add more weights as needed...
-
-// Update the font family variable
-$font-aeonik: 'Aeonik', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+.leading-tight { line-height: 1.25; }     // Compact
+.leading-snug { line-height: 1.375; }     // Balanced
+.leading-normal { line-height: 1.5; }     // Standard
+.leading-relaxed { line-height: 1.625; }  // Comfortable
+.leading-loose { line-height: 2; }        // Spacious
 ```
 
-## Font Weights Available
+### Typography Mixins
+```scss
+@include heading-1;      // Main page titles
+@include heading-2;      // Section titles
+@include heading-3;      // Subsection titles
+@include body-text;      // Standard body text
+@include body-text-large; // Enhanced body text
+@include caption;         // Caption text
+```
 
-- **300 (Light)**: Subtle text, captions
-- **400 (Regular)**: Default body text
-- **500 (Medium)**: Emphasis, buttons
-- **600 (Semibold)**: Strong emphasis, subheadings
-- **700 (Bold)**: Headings, highlights
+## Viewing the Demo
 
-## Font Sizes Available
+Navigate to `/font-demo` in your application to see all font weights, sizes, and examples in action.
 
-- **xs**: 12px - Captions, fine print
-- **sm**: 14px - Secondary text
-- **base**: 16px - Default body text
-- **lg**: 18px - Enhanced readability
-- **xl**: 20px - Subheadings
-- **2xl**: 24px - Section headings
-- **3xl**: 30px - Page titles
-- **4xl**: 36px - Hero text
+## If You Want to Use Aeonik Later
 
-## Best Practices
+If you obtain a commercial license for Aeonik font:
 
-1. **Use consistent font weights** throughout your application
-2. **Limit font sizes** to maintain hierarchy
-3. **Test readability** at different screen sizes
-4. **Use appropriate line heights** for content length
-5. **Maintain contrast ratios** for accessibility
+1. Download the font files (.woff2, .woff, .ttf)
+2. Place them in `src/assets/fonts/`
+3. Update `_fonts.scss` to use `@font-face` declarations
+4. Replace `$font-primary` with your Aeonik font family
 
-## Testing the Font
+## Browser Support
 
-To see the font in action, you can:
+Inter font supports:
+- ✅ Modern browsers (Chrome, Firefox, Safari, Edge)
+- ✅ Variable font support for advanced features
+- ✅ Fallback to system fonts for older browsers
 
-1. **Run the application**: `ng serve`
-2. **Navigate to the demo component** (if added to routing)
-3. **Inspect elements** in browser dev tools to see applied fonts
+## Performance
 
-## Troubleshooting
-
-- **Font not loading**: Check if the Google Fonts URL is accessible
-- **Font not applying**: Ensure the fonts partial is imported in `styles.scss`
-- **Build errors**: Verify SCSS syntax and file paths
-
-## Next Steps
-
-1. **Customize font sizes** and weights as needed
-2. **Add more font variants** (italic, condensed, etc.)
-3. **Create component-specific font styles**
-4. **Implement responsive typography** using media queries
+- Font files are loaded from Google Fonts CDN
+- Optimized for fast loading
+- Includes only the weights you need
+- Automatic font-display: swap for better performance

--- a/FONT_SETUP.md
+++ b/FONT_SETUP.md
@@ -1,0 +1,168 @@
+# Aeonik Font Setup Guide
+
+This guide explains how to use the Aeonik font in your Angular application.
+
+## What's Been Added
+
+1. **Font Configuration File** (`src/assets/styles/_fonts.scss`)
+   - Font family variables
+   - Font weight variables (300, 400, 500, 600, 700)
+   - Font size variables (xs to 4xl)
+   - Line height variables
+   - Utility classes and mixins
+
+2. **Updated Main Styles** (`src/styles.scss`)
+   - Imports the fonts configuration
+   - Applies Aeonik as the default font family
+
+3. **Demo Component** (`src/app/font-demo/font-demo.component.ts`)
+   - Showcases all font weights, sizes, and line heights
+   - Provides usage examples
+
+## Current Setup
+
+The application currently uses **Inter** as a fallback font since Aeonik is a commercial font. If you have the commercial Aeonik font files, you can replace Inter with Aeonik.
+
+## How to Use
+
+### 1. Basic Font Usage
+
+The Aeonik font is automatically applied to all text in your application. You can override it using utility classes:
+
+```html
+<!-- Font weights -->
+<p class="font-light">Light text</p>
+<p class="font-regular">Regular text</p>
+<p class="font-medium">Medium text</p>
+<p class="font-semibold">Semibold text</p>
+<p class="font-bold">Bold text</p>
+
+<!-- Font sizes -->
+<p class="text-xs">Extra small</p>
+<p class="text-sm">Small</p>
+<p class="text-base">Base size</p>
+<p class="text-lg">Large</p>
+<p class="text-xl">Extra large</p>
+<p class="text-2xl">2XL</p>
+<p class="text-3xl">3XL</p>
+<p class="text-4xl">4XL</p>
+
+<!-- Line heights -->
+<p class="leading-tight">Tight spacing</p>
+<p class="leading-normal">Normal spacing</p>
+<p class="leading-relaxed">Relaxed spacing</p>
+```
+
+### 2. Using SCSS Mixins
+
+In your component styles, you can use the provided mixins:
+
+```scss
+.my-component {
+  @include font-aeonik($font-weight-medium, $font-size-lg, $line-height-normal);
+}
+
+.heading {
+  @include font-heading;
+}
+
+.body-text {
+  @include font-body;
+}
+
+.caption {
+  @include font-caption;
+}
+```
+
+### 3. Using CSS Variables
+
+You can also use CSS custom properties:
+
+```scss
+.my-text {
+  font-family: var(--font-aeonik);
+  font-weight: var(--font-weight-medium);
+}
+```
+
+## Adding Commercial Aeonik Font
+
+If you have the commercial Aeonik font files:
+
+1. **Place font files** in `src/assets/fonts/` directory
+2. **Update the fonts partial** (`src/assets/styles/_fonts.scss`):
+
+```scss
+// Replace the Inter import with Aeonik font-face declarations
+@font-face {
+  font-family: 'Aeonik';
+  src: url('../fonts/Aeonik-Regular.woff2') format('woff2'),
+       url('../fonts/Aeonik-Regular.woff') format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Aeonik';
+  src: url('../fonts/Aeonik-Medium.woff2') format('woff2'),
+       url('../fonts/Aeonik-Medium.woff') format('woff');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+// Add more weights as needed...
+
+// Update the font family variable
+$font-aeonik: 'Aeonik', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+```
+
+## Font Weights Available
+
+- **300 (Light)**: Subtle text, captions
+- **400 (Regular)**: Default body text
+- **500 (Medium)**: Emphasis, buttons
+- **600 (Semibold)**: Strong emphasis, subheadings
+- **700 (Bold)**: Headings, highlights
+
+## Font Sizes Available
+
+- **xs**: 12px - Captions, fine print
+- **sm**: 14px - Secondary text
+- **base**: 16px - Default body text
+- **lg**: 18px - Enhanced readability
+- **xl**: 20px - Subheadings
+- **2xl**: 24px - Section headings
+- **3xl**: 30px - Page titles
+- **4xl**: 36px - Hero text
+
+## Best Practices
+
+1. **Use consistent font weights** throughout your application
+2. **Limit font sizes** to maintain hierarchy
+3. **Test readability** at different screen sizes
+4. **Use appropriate line heights** for content length
+5. **Maintain contrast ratios** for accessibility
+
+## Testing the Font
+
+To see the font in action, you can:
+
+1. **Run the application**: `ng serve`
+2. **Navigate to the demo component** (if added to routing)
+3. **Inspect elements** in browser dev tools to see applied fonts
+
+## Troubleshooting
+
+- **Font not loading**: Check if the Google Fonts URL is accessible
+- **Font not applying**: Ensure the fonts partial is imported in `styles.scss`
+- **Build errors**: Verify SCSS syntax and file paths
+
+## Next Steps
+
+1. **Customize font sizes** and weights as needed
+2. **Add more font variants** (italic, condensed, etc.)
+3. **Create component-specific font styles**
+4. **Implement responsive typography** using media queries

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { HomeComponent } from './features/home/home.component';
 import { AboutComponent } from './features/about/about.component';
 import { ContactComponent } from './features/contact/contact.component';
+import { FontDemoComponent } from './font-demo/font-demo.component';
 
 export const routes: Routes = [
   {
@@ -20,5 +21,9 @@ export const routes: Routes = [
   {
     path: 'contact',
     component: ContactComponent,
+  },
+  {
+    path: 'font-demo',
+    component: FontDemoComponent,
   },
 ];

--- a/src/app/font-demo/font-demo.component.ts
+++ b/src/app/font-demo/font-demo.component.ts
@@ -6,15 +6,19 @@ import { Component } from '@angular/core';
   imports: [],
   template: `
     <div class="font-demo">
-      <h1 class="display-text">Aeonik Font Demo</h1>
+      <h1 class="display-text">Inter Font Demo</h1>
       
       <section class="font-weights">
         <h2>Font Weights</h2>
-        <p class="font-light">Light weight (300) - Perfect for subtle text</p>
+        <p class="font-thin">Thin weight (100) - Ultra light text</p>
+        <p class="font-extralight">Extra Light weight (200) - Very light text</p>
+        <p class="font-light">Light weight (300) - Light text</p>
         <p class="font-regular">Regular weight (400) - Default body text</p>
         <p class="font-medium">Medium weight (500) - Emphasis text</p>
         <p class="font-semibold">Semibold weight (600) - Strong emphasis</p>
         <p class="font-bold">Bold weight (700) - Headings and highlights</p>
+        <p class="font-extrabold">Extra Bold weight (800) - Heavy headings</p>
+        <p class="font-black">Black weight (900) - Maximum emphasis</p>
       </section>
 
       <section class="font-sizes">
@@ -25,24 +29,42 @@ import { Component } from '@angular/core';
         <p class="text-lg">Large (18px) - Enhanced readability</p>
         <p class="text-xl">Extra Large (20px) - Subheadings</p>
         <p class="text-2xl">2XL (24px) - Section headings</p>
-        <p class="text-3xl">3XL (30px) - Page titles</p>
-        <p class="text-4xl">4XL (36px) - Hero text</p>
+        <p class="text-3xl">3XL (30px) - Page headings</p>
+        <p class="text-4xl">4XL (36px) - Main titles</p>
+        <p class="text-5xl">5XL (48px) - Hero text</p>
+        <p class="text-6xl">6XL (60px) - Display text</p>
       </section>
 
       <section class="line-heights">
         <h2>Line Heights</h2>
-        <p class="leading-tight">Tight line height (1.25) - Good for headings and short text</p>
-        <p class="leading-normal">Normal line height (1.5) - Standard for body text</p>
-        <p class="leading-relaxed">Relaxed line height (1.75) - Better for long-form content</p>
+        <p class="leading-tight">Tight line height (1.25) - Compact text</p>
+        <p class="leading-snug">Snug line height (1.375) - Balanced text</p>
+        <p class="leading-normal">Normal line height (1.5) - Standard text</p>
+        <p class="leading-relaxed">Relaxed line height (1.625) - Comfortable reading</p>
+        <p class="leading-loose">Loose line height (2) - Spacious text</p>
       </section>
 
-      <section class="usage-examples">
-        <h2>Usage Examples</h2>
-        <div class="card">
-          <h3 class="card-title">Card Title</h3>
-          <p class="card-body">This is a sample card with Aeonik font. The text should be clean and readable.</p>
-          <button class="card-button">Action Button</button>
-        </div>
+      <section class="typography-examples">
+        <h2>Typography Examples</h2>
+        <h1 class="heading-1">Heading 1 - Main Page Title</h1>
+        <h2 class="heading-2">Heading 2 - Section Title</h2>
+        <h3 class="heading-3">Heading 3 - Subsection Title</h3>
+        <p class="body-text-large">This is large body text for enhanced readability and better user experience.</p>
+        <p class="body-text">This is standard body text that provides the main content of your application.</p>
+        <p class="caption">This is caption text for smaller details and metadata.</p>
+      </section>
+
+      <section class="font-features">
+        <h2>Font Features</h2>
+        <p><strong>Inter</strong> is a variable font family carefully crafted for computer screens.</p>
+        <p>Features include:</p>
+        <ul>
+          <li>Variable font with 9 weights (100-900)</li>
+          <li>Optimized for screen readability</li>
+          <li>Tall x-height for better legibility</li>
+          <li>OpenType features for professional typography</li>
+          <li>Free and open source</li>
+        </ul>
       </section>
     </div>
   `,
@@ -51,69 +73,101 @@ import { Component } from '@angular/core';
       max-width: 800px;
       margin: 0 auto;
       padding: 2rem;
-      font-family: var(--font-aeonik, 'Inter', sans-serif);
+      font-family: 'Inter', sans-serif;
     }
 
     .display-text {
-      font-size: 2.5rem;
-      font-weight: 700;
+      font-size: 3rem;
+      font-weight: 900;
       text-align: center;
       margin-bottom: 3rem;
-      color: #333;
+      color: #1a1a1a;
     }
 
     section {
       margin-bottom: 3rem;
-      padding: 1.5rem;
-      border: 1px solid #e0e0e0;
+      padding: 2rem;
+      background: #f8f9fa;
       border-radius: 8px;
-      background: #fafafa;
     }
 
     h2 {
       font-size: 1.5rem;
-      font-weight: 600;
-      margin-bottom: 1rem;
-      color: #444;
+      font-weight: 700;
+      margin-bottom: 1.5rem;
+      color: #2c3e50;
     }
 
     p {
       margin: 0.5rem 0;
-      color: #666;
+      color: #34495e;
     }
 
-    .card {
-      background: white;
-      padding: 1.5rem;
-      border-radius: 8px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    .font-weights p {
+      font-size: 1.1rem;
     }
 
-    .card-title {
-      font-size: 1.25rem;
-      font-weight: 600;
-      margin-bottom: 0.5rem;
-      color: #333;
-    }
-
-    .card-body {
-      margin-bottom: 1rem;
-      color: #555;
-    }
-
-    .card-button {
-      background: #007bff;
-      color: white;
-      border: none;
-      padding: 0.5rem 1rem;
-      border-radius: 4px;
+    .font-sizes p {
       font-weight: 500;
-      cursor: pointer;
-      transition: background-color 0.2s;
     }
 
-    .card-button:hover {
-      background: #0056b3;
+    .line-heights p {
+      font-size: 1rem;
+      font-weight: 400;
+    }
+
+    .typography-examples h1 {
+      font-size: 2.5rem;
+      font-weight: 900;
+      margin: 1rem 0;
+      color: #1a1a1a;
+    }
+
+    .typography-examples h2 {
+      font-size: 2rem;
+      font-weight: 700;
+      margin: 1rem 0;
+      color: #2c3e50;
+    }
+
+    .typography-examples h3 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin: 1rem 0;
+      color: #34495e;
+    }
+
+    .body-text-large {
+      font-size: 1.125rem;
+      line-height: 1.625;
+      margin: 1rem 0;
+    }
+
+    .body-text {
+      font-size: 1rem;
+      line-height: 1.5;
+      margin: 1rem 0;
+    }
+
+    .caption {
+      font-size: 0.875rem;
+      line-height: 1.5;
+      margin: 1rem 0;
+      color: #7f8c8d;
+    }
+
+    .font-features ul {
+      margin: 1rem 0;
+      padding-left: 1.5rem;
+    }
+
+    .font-features li {
+      margin: 0.5rem 0;
+      line-height: 1.6;
+    }
+
+    strong {
+      font-weight: 700;
     }
   `]
 })

--- a/src/app/font-demo/font-demo.component.ts
+++ b/src/app/font-demo/font-demo.component.ts
@@ -1,0 +1,120 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-font-demo',
+  standalone: true,
+  imports: [],
+  template: `
+    <div class="font-demo">
+      <h1 class="display-text">Aeonik Font Demo</h1>
+      
+      <section class="font-weights">
+        <h2>Font Weights</h2>
+        <p class="font-light">Light weight (300) - Perfect for subtle text</p>
+        <p class="font-regular">Regular weight (400) - Default body text</p>
+        <p class="font-medium">Medium weight (500) - Emphasis text</p>
+        <p class="font-semibold">Semibold weight (600) - Strong emphasis</p>
+        <p class="font-bold">Bold weight (700) - Headings and highlights</p>
+      </section>
+
+      <section class="font-sizes">
+        <h2>Font Sizes</h2>
+        <p class="text-xs">Extra Small (12px) - Captions and fine print</p>
+        <p class="text-sm">Small (14px) - Secondary text</p>
+        <p class="text-base">Base (16px) - Default body text</p>
+        <p class="text-lg">Large (18px) - Enhanced readability</p>
+        <p class="text-xl">Extra Large (20px) - Subheadings</p>
+        <p class="text-2xl">2XL (24px) - Section headings</p>
+        <p class="text-3xl">3XL (30px) - Page titles</p>
+        <p class="text-4xl">4XL (36px) - Hero text</p>
+      </section>
+
+      <section class="line-heights">
+        <h2>Line Heights</h2>
+        <p class="leading-tight">Tight line height (1.25) - Good for headings and short text</p>
+        <p class="leading-normal">Normal line height (1.5) - Standard for body text</p>
+        <p class="leading-relaxed">Relaxed line height (1.75) - Better for long-form content</p>
+      </section>
+
+      <section class="usage-examples">
+        <h2>Usage Examples</h2>
+        <div class="card">
+          <h3 class="card-title">Card Title</h3>
+          <p class="card-body">This is a sample card with Aeonik font. The text should be clean and readable.</p>
+          <button class="card-button">Action Button</button>
+        </div>
+      </section>
+    </div>
+  `,
+  styles: [`
+    .font-demo {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 2rem;
+      font-family: var(--font-aeonik, 'Inter', sans-serif);
+    }
+
+    .display-text {
+      font-size: 2.5rem;
+      font-weight: 700;
+      text-align: center;
+      margin-bottom: 3rem;
+      color: #333;
+    }
+
+    section {
+      margin-bottom: 3rem;
+      padding: 1.5rem;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      background: #fafafa;
+    }
+
+    h2 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin-bottom: 1rem;
+      color: #444;
+    }
+
+    p {
+      margin: 0.5rem 0;
+      color: #666;
+    }
+
+    .card {
+      background: white;
+      padding: 1.5rem;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+
+    .card-title {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: #333;
+    }
+
+    .card-body {
+      margin-bottom: 1rem;
+      color: #555;
+    }
+
+    .card-button {
+      background: #007bff;
+      color: white;
+      border: none;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background-color 0.2s;
+    }
+
+    .card-button:hover {
+      background: #0056b3;
+    }
+  `]
+})
+export class FontDemoComponent {}

--- a/src/app/shared/menu/menu.component.html
+++ b/src/app/shared/menu/menu.component.html
@@ -15,7 +15,7 @@
       [bubbleFloating]="true"
       [bubbleExpanded]="isOpen()"
       [bubbleIndex]="0"
-      [bubbleCount]="3"
+      [bubbleCount]="4"
       type="button"
       routerLink="/home"
       routerLinkActive="active"
@@ -34,7 +34,7 @@
       [bubbleFloating]="true"
       [bubbleExpanded]="isOpen()"
       [bubbleIndex]="1"
-      [bubbleCount]="3"
+      [bubbleCount]="4"
       type="button"
       routerLink="/about"
       routerLinkActive="active"
@@ -53,7 +53,7 @@
       [bubbleFloating]="true"
       [bubbleExpanded]="isOpen()"
       [bubbleIndex]="2"
-      [bubbleCount]="3"
+      [bubbleCount]="4"
       type="button"
       routerLink="/contact"
       routerLinkActive="active"
@@ -67,6 +67,26 @@
       [bubbleWobbleSpeed]="0.9"
     >
       Contact
+    </button>
+    <button
+      bubble
+      [bubbleFloating]="true"
+      [bubbleExpanded]="isOpen()"
+      [bubbleIndex]="3"
+      [bubbleCount]="4"
+      type="button"
+      routerLink="/font-demo"
+      routerLinkActive="active"
+      class="font-demo-button"
+      [style.--bubble-size.px]="sizes[3]"
+      [bubbleGlassStrength]="88"
+      [bubbleGlassDepth]="19"
+      [bubbleChromaticAberration]="1.15"
+      [bubbleGlassBlur]="0.95"
+      [bubbleWobbleIntensity]="0.75"
+      [bubbleWobbleSpeed]="0.82"
+    >
+      Font Demo
     </button>
   </div>
 </div>

--- a/src/app/shared/menu/menu.component.ts
+++ b/src/app/shared/menu/menu.component.ts
@@ -14,7 +14,7 @@ export class MenuComponent {
 
   readonly isOpen = signal(false);
   // Larger nav bubbles
-  readonly sizes = [84, 96, 108];
+  readonly sizes = [84, 96, 108, 92];
 
   toggleMenu(): void {
     const wasOpen = this.isOpen();

--- a/src/assets/styles/_fonts.scss
+++ b/src/assets/styles/_fonts.scss
@@ -1,19 +1,23 @@
-// Aeonik Font Configuration
-// Note: This uses Inter as a fallback since Aeonik is a commercial font
-// If you have the commercial Aeonik font files, replace the font-family values
+// Modern Font Configuration
+// Using Inter as the primary font - it's free, modern, and has excellent readability
+// Similar aesthetic to Aeonik but legally available for free
 
-// Font import (Google Fonts fallback)
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+// Font import from Google Fonts
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
 
 // Font family variables
-$font-aeonik: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+$font-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
 
 // Font weight variables
+$font-weight-thin: 100;
+$font-weight-extralight: 200;
 $font-weight-light: 300;
 $font-weight-regular: 400;
 $font-weight-medium: 500;
 $font-weight-semibold: 600;
 $font-weight-bold: 700;
+$font-weight-extrabold: 800;
+$font-weight-black: 900;
 
 // Font size variables
 $font-size-xs: 0.75rem;    // 12px
@@ -24,44 +28,28 @@ $font-size-xl: 1.25rem;    // 20px
 $font-size-2xl: 1.5rem;    // 24px
 $font-size-3xl: 1.875rem;  // 30px
 $font-size-4xl: 2.25rem;   // 36px
+$font-size-5xl: 3rem;      // 48px
+$font-size-6xl: 3.75rem;   // 60px
 
 // Line height variables
 $line-height-tight: 1.25;
+$line-height-snug: 1.375;
 $line-height-normal: 1.5;
-$line-height-relaxed: 1.75;
+$line-height-relaxed: 1.625;
+$line-height-loose: 2;
 
-// Font mixins
-@mixin font-aeonik($weight: $font-weight-regular, $size: $font-size-base, $line-height: $line-height-normal) {
-  font-family: $font-aeonik;
-  font-weight: $weight;
-  font-size: $size;
-  line-height: $line-height;
-}
-
-@mixin font-display {
-  @include font-aeonik($font-weight-semibold, $font-size-2xl, $line-height-tight);
-}
-
-@mixin font-heading {
-  @include font-aeonik($font-weight-medium, $font-size-xl, $line-height-tight);
-}
-
-@mixin font-body {
-  @include font-aeonik($font-weight-regular, $font-size-base, $line-height-normal);
-}
-
-@mixin font-caption {
-  @include font-aeonik($font-weight-regular, $font-size-sm, $line-height-normal);
-}
-
-// Utility classes
-.font-aeonik { font-family: $font-aeonik; }
+// Font utility classes
+.font-thin { font-weight: $font-weight-thin; }
+.font-extralight { font-weight: $font-weight-extralight; }
 .font-light { font-weight: $font-weight-light; }
 .font-regular { font-weight: $font-weight-regular; }
 .font-medium { font-weight: $font-weight-medium; }
 .font-semibold { font-weight: $font-weight-semibold; }
 .font-bold { font-weight: $font-weight-bold; }
+.font-extrabold { font-weight: $font-weight-extrabold; }
+.font-black { font-weight: $font-weight-black; }
 
+// Font size utility classes
 .text-xs { font-size: $font-size-xs; }
 .text-sm { font-size: $font-size-sm; }
 .text-base { font-size: $font-size-base; }
@@ -70,7 +58,55 @@ $line-height-relaxed: 1.75;
 .text-2xl { font-size: $font-size-2xl; }
 .text-3xl { font-size: $font-size-3xl; }
 .text-4xl { font-size: $font-size-4xl; }
+.text-5xl { font-size: $font-size-5xl; }
+.text-6xl { font-size: $font-size-6xl; }
 
+// Line height utility classes
 .leading-tight { line-height: $line-height-tight; }
+.leading-snug { line-height: $line-height-snug; }
 .leading-normal { line-height: $line-height-normal; }
 .leading-relaxed { line-height: $line-height-relaxed; }
+.leading-loose { line-height: $line-height-loose; }
+
+// Mixins for consistent typography
+@mixin heading-1 {
+  font-family: $font-primary;
+  font-weight: $font-weight-bold;
+  font-size: $font-size-4xl;
+  line-height: $line-height-tight;
+}
+
+@mixin heading-2 {
+  font-family: $font-primary;
+  font-weight: $font-weight-semibold;
+  font-size: $font-size-3xl;
+  line-height: $line-height-snug;
+}
+
+@mixin heading-3 {
+  font-family: $font-primary;
+  font-weight: $font-weight-semibold;
+  font-size: $font-size-2xl;
+  line-height: $line-height-snug;
+}
+
+@mixin body-text {
+  font-family: $font-primary;
+  font-weight: $font-weight-regular;
+  font-size: $font-size-base;
+  line-height: $line-height-normal;
+}
+
+@mixin body-text-large {
+  font-family: $font-primary;
+  font-weight: $font-weight-regular;
+  font-size: $font-size-lg;
+  line-height: $line-height-relaxed;
+}
+
+@mixin caption {
+  font-family: $font-primary;
+  font-weight: $font-weight-regular;
+  font-size: $font-size-sm;
+  line-height: $line-height-normal;
+}

--- a/src/assets/styles/_fonts.scss
+++ b/src/assets/styles/_fonts.scss
@@ -1,0 +1,76 @@
+// Aeonik Font Configuration
+// Note: This uses Inter as a fallback since Aeonik is a commercial font
+// If you have the commercial Aeonik font files, replace the font-family values
+
+// Font import (Google Fonts fallback)
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+// Font family variables
+$font-aeonik: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+
+// Font weight variables
+$font-weight-light: 300;
+$font-weight-regular: 400;
+$font-weight-medium: 500;
+$font-weight-semibold: 600;
+$font-weight-bold: 700;
+
+// Font size variables
+$font-size-xs: 0.75rem;    // 12px
+$font-size-sm: 0.875rem;   // 14px
+$font-size-base: 1rem;     // 16px
+$font-size-lg: 1.125rem;   // 18px
+$font-size-xl: 1.25rem;    // 20px
+$font-size-2xl: 1.5rem;    // 24px
+$font-size-3xl: 1.875rem;  // 30px
+$font-size-4xl: 2.25rem;   // 36px
+
+// Line height variables
+$line-height-tight: 1.25;
+$line-height-normal: 1.5;
+$line-height-relaxed: 1.75;
+
+// Font mixins
+@mixin font-aeonik($weight: $font-weight-regular, $size: $font-size-base, $line-height: $line-height-normal) {
+  font-family: $font-aeonik;
+  font-weight: $weight;
+  font-size: $size;
+  line-height: $line-height;
+}
+
+@mixin font-display {
+  @include font-aeonik($font-weight-semibold, $font-size-2xl, $line-height-tight);
+}
+
+@mixin font-heading {
+  @include font-aeonik($font-weight-medium, $font-size-xl, $line-height-tight);
+}
+
+@mixin font-body {
+  @include font-aeonik($font-weight-regular, $font-size-base, $line-height-normal);
+}
+
+@mixin font-caption {
+  @include font-aeonik($font-weight-regular, $font-size-sm, $line-height-normal);
+}
+
+// Utility classes
+.font-aeonik { font-family: $font-aeonik; }
+.font-light { font-weight: $font-weight-light; }
+.font-regular { font-weight: $font-weight-regular; }
+.font-medium { font-weight: $font-weight-medium; }
+.font-semibold { font-weight: $font-weight-semibold; }
+.font-bold { font-weight: $font-weight-bold; }
+
+.text-xs { font-size: $font-size-xs; }
+.text-sm { font-size: $font-size-sm; }
+.text-base { font-size: $font-size-base; }
+.text-lg { font-size: $font-size-lg; }
+.text-xl { font-size: $font-size-xl; }
+.text-2xl { font-size: $font-size-2xl; }
+.text-3xl { font-size: $font-size-3xl; }
+.text-4xl { font-size: $font-size-4xl; }
+
+.leading-tight { line-height: $line-height-tight; }
+.leading-normal { line-height: $line-height-normal; }
+.leading-relaxed { line-height: $line-height-relaxed; }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,6 +17,9 @@ body {
   background-size: cover;
   background-attachment: fixed;
   /* Font styling is now handled by the fonts partial */
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-weight: 400;
+  line-height: 1.6;
 }
 
 button {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,9 +1,14 @@
 /* You can add global styles to this file, and also import other style files */
+
+/* Import fonts configuration */
+@use './assets/styles/fonts';
+
 @use './assets/styles/bubble.scss';
 
 html, body, app-root {
   height: 100%;
 }
+
 body {
   margin: 0;
   background-image: url('./assets/images/bg.jpg');
@@ -11,6 +16,7 @@ body {
   background-position: center center;
   background-size: cover;
   background-attachment: fixed;
+  /* Font styling is now handled by the fonts partial */
 }
 
 button {


### PR DESCRIPTION
Add Inter font as a free alternative to Aeonik, including a demo component and setup guide.

Aeonik is a commercial font and not freely available. Inter was chosen as a professional, open-source alternative with a similar modern aesthetic.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd6f3e05-0df0-414c-84fe-e0fb2005ebdf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd6f3e05-0df0-414c-84fe-e0fb2005ebdf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

